### PR TITLE
perf: переиспользовать длину cJSON-строки в горячем пути

### DIFF
--- a/src/http_server/http_server.c
+++ b/src/http_server/http_server.c
@@ -39,22 +39,25 @@ static void not_found(MHD_Connection *connection, HTTPResponse *response) {
 }
 
 /**
- * Generates an MHD_Response from string
+ * Generates an MHD_Response from string. If len is 0, falls back to strlen.
  */
 static MHD_Response *create_response_from_string(
-  char *string, const MHD_ResponseMemoryMode memory_mode
+  char *string, const MHD_ResponseMemoryMode memory_mode, const size_t len
 ) {
   return MHD_create_response_from_buffer(
-    strlen(string), (void *)string, memory_mode
+    len != 0 ? len : strlen(string), (void *)string, memory_mode
   );
 }
 
 /**
- * Generates an MHD_Response from static string
+ * Generates an MHD_Response from static string. If len is 0, falls back
+ * to strlen.
  */
-static MHD_Response *create_response_from_const_string(const char *string) {
+static MHD_Response *create_response_from_const_string(
+  const char *string, const size_t len
+) {
   return MHD_create_response_from_buffer(
-    strlen(string), (void *)string, MHD_RESPMEM_PERSISTENT
+    len != 0 ? len : strlen(string), (void *)string, MHD_RESPMEM_PERSISTENT
   );
 }
 
@@ -76,11 +79,11 @@ static MHD_Result queue_response(
   if (!mhd_response) {
     if (response->const_response) {
       mhd_response = create_response_from_const_string(
-        response->const_response
+        response->const_response, response->response_len
       );
     } else if (response->response) {
       mhd_response = create_response_from_string(
-        response->response, response->memory_mode
+        response->response, response->memory_mode, response->response_len
       );
     } else {
       mhd_response = MHD_create_response_from_buffer(
@@ -190,6 +193,7 @@ static MHD_Result process_get(
     .response = nullptr,
     .const_response = nullptr,
     .mhd_response = nullptr,
+    .response_len = 0,
     .content_type = nullptr,
     .memory_mode = MHD_RESPMEM_MUST_COPY,
     .status_code = MHD_HTTP_OK,

--- a/src/http_server/http_server.h
+++ b/src/http_server/http_server.h
@@ -6,6 +6,7 @@
 #define PG_STATUS_HTTP_SERVER_H
 
 #include <microhttpd.h>
+#include <stddef.h>
 
 typedef struct MHD_Daemon MHD_Daemon;
 typedef struct MHD_Connection MHD_Connection;
@@ -30,6 +31,10 @@ typedef struct HTTPResponse {
   // For complex cases, you can manually generate MHD_Response.
   // Use memory_mode for memory management.
   MHD_Response *mhd_response;
+
+  // Length of response / const_response in bytes. If non-zero, used
+  // verbatim; if 0, the server falls back to strlen at queue time.
+  size_t response_len;
 
   // Response type. It can be set by the server or specified by handler.
   const char *content_type;

--- a/src/main.c
+++ b/src/main.c
@@ -58,7 +58,7 @@ void get_all_hosts(MHD_Connection *connection, HTTPResponse *response) {
     cJSON_AddItemToArray(arr, json_obj);
   }
 
-  response->response = json_to_str(arr);
+  response->response = json_to_str(arr, &response->response_len);
   response->memory_mode = MHD_RESPMEM_MUST_FREE;
   response->content_type = "application/json";
 }
@@ -71,7 +71,7 @@ static void return_single_host(HTTPResponse *response, const char *host) {
   if (need_json_response(response)) {
     cJSON *json_obj = json_object();
     add_host_to_json(json_obj, host);
-    response->response = json_to_str(json_obj);
+    response->response = json_to_str(json_obj, &response->response_len);
     response->memory_mode = MHD_RESPMEM_MUST_FREE;
   } else {
     response->const_response = host;
@@ -235,7 +235,7 @@ static void get_host_status(
   cJSON *json_obj = json_object();
   add_host_status_to_json(json_obj, snap);
 
-  response->response = json_to_str(json_obj);
+  response->response = json_to_str(json_obj, &response->response_len);
   response->memory_mode = MHD_RESPMEM_MUST_FREE;
   response->content_type = "application/json";
 }
@@ -251,7 +251,9 @@ static void block_termination_signals(sigset_t *sigset) {
 }
 
 static void get_version(MHD_Connection *connection, HTTPResponse *response) {
-  response->const_response = "2.0.0";
+  static const char version[] = "2.0.0";
+  response->const_response = version;
+  response->response_len = sizeof(version) - 1;
 }
 
 static void wait_for_termination_signal(const sigset_t *sigset) {

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -460,15 +460,19 @@ void add_uint64_to_json_object(
 }
 
 /**
- * Converts json to string.
+ * Converts json to string. If len is not nullptr, writes the length
+ * of the result so the caller can avoid a second strlen pass.
  * The string must be freed by the caller.
  */
-char *json_to_str(cJSON *json) {
+char *json_to_str(cJSON *json, size_t *len) {
   assert(json);
   char *result = cJSON_PrintUnformatted(json);
   cJSON_Delete(json);
   if (!result) {
     raise_error("Can't convert json to string");
+  }
+  if (len) {
+    *len = strlen(result);
   }
   return result;
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -186,9 +186,11 @@ void add_bool_to_json_object(cJSON *obj, const char *key, bool val);
 void add_uint64_to_json_object(cJSON *obj, const char *key, uint64_t val);
 
 /**
- * Converts json to string.
+ * Converts json to string. If len is not nullptr, the length of the
+ * result is written to it in a single strlen pass right after cJSON
+ * printing, so the caller can avoid a second pass downstream.
  * The string must be freed by the caller.
  */
-char *json_to_str(cJSON *json);
+char *json_to_str(cJSON *json, size_t *len);
 
 #endif  // PG_STATUS_UTILS_H


### PR DESCRIPTION
Закрывает #20.

## Что
`create_response_from_string` и `create_response_from_const_string` делали `strlen` на уже сформированной строке. Для JSON-ответов длину можно посчитать один раз сразу после `cJSON_PrintUnformatted`.

- `json_to_str(cJSON*, size_t *len)` — если `len` не `nullptr`, длина пишется туда одним проходом
- в `HTTPResponse` добавлено поле `response_len`: 0 — fallback на `strlen`, иначе передаётся в MHD напрямую
- обновлены все три вызова `json_to_str` в main.c

Поведение plain-ответов не меняется (`response_len = 0` по умолчанию).

## Проверено
- cmake Release собирается без новых warning'ов

## Стоит проверить руками
- ответы `/hosts` и `/status` побайтно совпадают с прошлой версией (Content-Length тот же)