### PR TITLE
fix: значение Accept запроса утекало в Content-Type ответа

### DIFF
--- a/src/http_server/http_server.c
+++ b/src/http_server/http_server.c
@@ -90,11 +90,15 @@ static MHD_Result queue_response(
   }
 
   if (mhd_response) {
-    if (response->content_type != nullptr) {
-      MHD_add_response_header(
-        mhd_response, MHD_HTTP_HEADER_CONTENT_TYPE, response->content_type
-      );
+    const char *content_type = response->content_type;
+    if (content_type == nullptr) {
+      content_type = response->wants_json
+        ? "application/json"
+        : "text/plain; charset=utf-8";
     }
+    MHD_add_response_header(
+      mhd_response, MHD_HTTP_HEADER_CONTENT_TYPE, content_type
+    );
 
     ret = MHD_queue_response(connection, response->status_code, mhd_response);
 
@@ -166,12 +170,10 @@ static MHD_Result process_handler(
   MHD_Result result = MHD_NO;
   const request_handler_t handler = find_handler(method, path);
 
-  const char *content_type = MHD_lookup_connection_value(
+  const char *accept = MHD_lookup_connection_value(
     connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_ACCEPT
   );
-  if (content_type != nullptr) {
-    response->content_type = content_type;
-  }
+  response->wants_json = is_equal_strings(accept, "application/json");
 
   handler(connection, response);
 
@@ -191,6 +193,7 @@ static MHD_Result process_get(
     .const_response = nullptr,
     .mhd_response = nullptr,
     .content_type = nullptr,
+    .wants_json = false,
     .memory_mode = MHD_RESPMEM_MUST_COPY,
     .status_code = MHD_HTTP_OK,
   };
@@ -250,8 +253,7 @@ void stop_http_server(MHD_Daemon *daemon) {
 }
 
 bool need_json_response(const HTTPResponse *response) {
-  return response->content_type &&
-         is_equal_strings(response->content_type, "application/json");
+  return response->wants_json;
 }
 
 bool parse_get_param_uint(
@@ -291,4 +293,5 @@ bool parse_get_param_lsn(
 void bad_request(HTTPResponse *response, const char *const_response) {
   response->status_code = 400;
   response->const_response = const_response;
+  response->content_type = "application/json";
 }

--- a/src/http_server/http_server.h
+++ b/src/http_server/http_server.h
@@ -31,8 +31,15 @@ typedef struct HTTPResponse {
   // Use memory_mode for memory management.
   MHD_Response *mhd_response;
 
-  // Response type. It can be set by the server or specified by handler.
+  // Content-Type of the response. If a handler leaves it null, the
+  // server picks "application/json" or "text/plain; charset=utf-8"
+  // automatically based on wants_json.
   const char *content_type;
+
+  // Set by the server before calling a handler: true if the client
+  // asked for JSON in the Accept header. Handlers that can render in
+  // both formats use this flag via need_json_response().
+  bool wants_json;
 
   // What to do with the response after mhd gives the response to the client
   MHD_ResponseMemoryMode memory_mode;

--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,7 @@ static void return_single_host(HTTPResponse *response, const char *host) {
     add_host_to_json(json_obj, host);
     response->response = json_to_str(json_obj);
     response->memory_mode = MHD_RESPMEM_MUST_FREE;
+    response->content_type = "application/json";
   } else {
     response->const_response = host;
   }


### PR DESCRIPTION
Закрывает #17.

## Что
В `process_handler` значение `Accept` запроса записывалось в `response -> content_type`, и `queue_response` отдавал его клиенту как `Content-Type` ответа. На практике это давало `Content-Type: */*` для запросов без явного `Accept` и `Content-Type: text/html` для браузерных запросов к plain-эндпоинтам.

- В `HTTPResponse` добавлено отдельное поле `bool wants_json` — выставляется сервером по Accept
- `content_type` теперь хранит только реальный тип ответа
- `need_json_response` читает `wants_json` вместо `is_equal_strings(content_type, "application/json")`
- `queue_response` при null `content_type` подставляет `"application/json"` или `"text/plain; charset=utf-8"` по `wants_json`
- `return_single_host` (main.c) в JSON-ветке и error 400 в `get_host_status` явно выставляют `content_type = "application/json"`, чтобы JSON-ответы всегда уходили с правильным заголовком

## Проверено
- cmake Release собирается без новых warning'ов

## Стоит проверить руками
- `curl -i .../master` без Accept → `Content-Type: text/plain; charset=utf-8`
- `curl -i -H 'Accept: application/json' .../master` → `Content-Type: application/json` + JSON body
- `curl -i .../hosts` → `Content-Type: application/json` + JSON body
- `curl -i .../status?host=...` → `Content-Type: application/json`
- `curl -i .../status` (без host) → 400 + `Content-Type: application/json` + error body