### PR TITLE
perf: кэшировать ответ GET /hosts в фоновом writer'е

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -9,56 +9,15 @@
 #include "pg_monitor.h"
 #include "utils.h"
 
-static void add_host_to_json(cJSON *json_obj, const char *host) {
-  if (!host) {
-    add_null_to_json_object(json_obj, "host");
-  } else {
-    add_str_to_json_object(json_obj, "host", host);
-  }
-}
-
-static void add_host_status_to_json(
-  cJSON *json_obj, const MonitorSnapshot snap
-) {
-  add_bool_to_json_object(json_obj, "master", snap.status.master);
-  add_bool_to_json_object(json_obj, "alive", snap.status.alive);
-  if (snap.status.alive) {
-    add_uint64_to_json_object(json_obj, "lag_ms", snap.lag_ms);
-    add_bool_to_json_object(
-      json_obj, "sync_by_time", snap.lag_ms <= parameters.sync_max_lag_ms
-    );
-
-    add_uint64_to_json_object(json_obj, "lag_bytes", snap.lag_bytes);
-    add_bool_to_json_object(
-      json_obj, "sync_by_bytes", snap.lag_bytes <= parameters.sync_max_lag_bytes
-    );
-
-    char *lsn_str = format_lsn(snap.lsn);
-    add_str_to_json_object(json_obj, "lsn", lsn_str);
-    free(lsn_str);
-  } else {
-    add_null_to_json_object(json_obj, "lag_ms");
-    add_bool_to_json_object(json_obj, "sync_by_time", false);
-    add_null_to_json_object(json_obj, "lag_bytes");
-    add_bool_to_json_object(json_obj, "sync_by_bytes", false);
-    add_null_to_json_object(json_obj, "lsn");
-  }
-}
-
 void get_all_hosts(MHD_Connection *connection, HTTPResponse *response) {
-  cJSON *arr = json_array();
-  for (unsigned int i = 0; i < host_count; i++) {
-    const MonitorHost *mon_host = &monitor_host_list[i];
-    cJSON *json_obj = json_object();
-    add_host_to_json(json_obj, mon_host->host);
-
-    const MonitorSnapshot snap = atomic_get_snapshot(mon_host);
-    add_host_status_to_json(json_obj, snap);
-
-    cJSON_AddItemToArray(arr, json_obj);
+  size_t len = 0;
+  char *json = copy_hosts_cache(&len);
+  if (!json) {
+    response->const_response = "[]";
+    response->content_type = "application/json";
+    return;
   }
-
-  response->response = json_to_str(arr);
+  response->response = json;
   response->memory_mode = MHD_RESPMEM_MUST_FREE;
   response->content_type = "application/json";
 }

--- a/src/pg_monitor/host_list.c
+++ b/src/pg_monitor/host_list.c
@@ -135,3 +135,137 @@ void init_monitor_host_list(void) {
 void save_master_index(const int i) {
   atomic_store_explicit(&master_index, i, memory_order_relaxed);
 }
+
+// ------------------------ /hosts JSON cache ------------------------
+
+void add_host_to_json(cJSON *json_obj, const char *host) {
+  if (!host) {
+    add_null_to_json_object(json_obj, "host");
+  } else {
+    add_str_to_json_object(json_obj, "host", host);
+  }
+}
+
+void add_host_status_to_json(
+  cJSON *json_obj, const MonitorSnapshot snap
+) {
+  add_bool_to_json_object(json_obj, "master", snap.status.master);
+  add_bool_to_json_object(json_obj, "alive", snap.status.alive);
+  if (snap.status.alive) {
+    add_uint64_to_json_object(json_obj, "lag_ms", snap.lag_ms);
+    add_bool_to_json_object(
+      json_obj, "sync_by_time", snap.lag_ms <= parameters.sync_max_lag_ms
+    );
+
+    add_uint64_to_json_object(json_obj, "lag_bytes", snap.lag_bytes);
+    add_bool_to_json_object(
+      json_obj, "sync_by_bytes",
+      snap.lag_bytes <= parameters.sync_max_lag_bytes
+    );
+
+    char *lsn_str = format_lsn(snap.lsn);
+    add_str_to_json_object(json_obj, "lsn", lsn_str);
+    free(lsn_str);
+  } else {
+    add_null_to_json_object(json_obj, "lag_ms");
+    add_bool_to_json_object(json_obj, "sync_by_time", false);
+    add_null_to_json_object(json_obj, "lag_bytes");
+    add_bool_to_json_object(json_obj, "sync_by_bytes", false);
+    add_null_to_json_object(json_obj, "lsn");
+  }
+}
+
+/**
+ * One generation of the /hosts JSON cache. Pointer to the current
+ * generation lives in `hosts_cache` and is updated atomically.
+ */
+typedef struct {
+  char *str;
+  size_t len;
+} HostsCacheEntry;
+
+/**
+ * Currently published /hosts JSON. Readers atomically load this and
+ * memcpy out before returning to MHD.
+ */
+static _Atomic(HostsCacheEntry *) hosts_cache = nullptr;
+
+/**
+ * Previous generation kept alive for one extra cycle as a grace period
+ * for any reader that loaded `hosts_cache` just before the writer swapped
+ * it. Writer-private — only the poll thread touches this.
+ */
+static HostsCacheEntry *prev_hosts_cache = nullptr;
+
+static void free_hosts_cache_entry(HostsCacheEntry *entry) {
+  if (entry) {
+    free(entry->str);
+    free(entry);
+  }
+}
+
+/**
+ * Builds a fresh /hosts JSON string. Runs outside any critical section
+ * so the writer doesn't compete with readers during cJSON allocations.
+ */
+static char *build_hosts_json(size_t *len) {
+  cJSON *arr = json_array();
+  for (unsigned int i = 0; i < host_count; i++) {
+    const MonitorHost *mon_host = &monitor_host_list[i];
+    cJSON *json_obj = json_object();
+    add_host_to_json(json_obj, mon_host->host);
+
+    const MonitorSnapshot snap = atomic_get_snapshot(mon_host);
+    add_host_status_to_json(json_obj, snap);
+
+    cJSON_AddItemToArray(arr, json_obj);
+  }
+  char *result = json_to_str(arr);
+  *len = strlen(result);
+  return result;
+}
+
+void update_hosts_cache(void) {
+  HostsCacheEntry *next = malloc(sizeof(HostsCacheEntry));
+  if (!next) {
+    raise_error("Can't allocate /hosts cache entry");
+  }
+  next->str = build_hosts_json(&next->len);
+
+  HostsCacheEntry *swapped = atomic_exchange_explicit(
+    &hosts_cache, next, memory_order_acq_rel
+  );
+
+  // Free the generation older than `swapped` — by the time the writer
+  // is on iteration N, no in-flight reader still holds a pointer from
+  // iteration N-2 (HTTP requests finish in milliseconds; check_hosts
+  // cycles are sub-second at minimum).
+  free_hosts_cache_entry(prev_hosts_cache);
+  prev_hosts_cache = swapped;
+}
+
+char *copy_hosts_cache(size_t *len) {
+  const HostsCacheEntry *entry = atomic_load_explicit(
+    &hosts_cache, memory_order_acquire
+  );
+  if (!entry) {
+    *len = 0;
+    return nullptr;
+  }
+  char *copy = malloc(entry->len + 1);
+  if (!copy) {
+    raise_error("Can't allocate /hosts cache copy");
+  }
+  memcpy(copy, entry->str, entry->len + 1);
+  *len = entry->len;
+  return copy;
+}
+
+void free_hosts_cache(void) {
+  HostsCacheEntry *entry = atomic_exchange_explicit(
+    &hosts_cache, nullptr, memory_order_acq_rel
+  );
+  free_hosts_cache_entry(entry);
+  free_hosts_cache_entry(prev_hosts_cache);
+  prev_hosts_cache = nullptr;
+}

--- a/src/pg_monitor/pg_monitor.c
+++ b/src/pg_monitor/pg_monitor.c
@@ -59,6 +59,8 @@ static void check_hosts(void) {
     save_master_index(-1);
   }
 
+  update_hosts_cache();
+
   (void)fflush(stdout);
 }
 
@@ -150,6 +152,8 @@ void stop_pg_monitor(void) {
   close(stop_pipe[1]);
   stop_pipe[0] = -1;
   stop_pipe[1] = -1;
+
+  free_hosts_cache();
 
   printf("pg_monitor stopped\n");
 }

--- a/src/pg_monitor/pg_monitor.h
+++ b/src/pg_monitor/pg_monitor.h
@@ -5,7 +5,9 @@
 #ifndef PG_STATUS_PG_MONITOR_H
 #define PG_STATUS_PG_MONITOR_H
 
+#include <cjson/cJSON.h>
 #include <pthread.h>
+#include <stddef.h>
 #include <stdint.h>
 
 // ------------------------ Parameters ------------------------
@@ -150,6 +152,39 @@ void init_monitor_host_list(void);
  * Atomically saves the current master index in the host array.
  */
 void save_master_index(int i);
+
+// ------------------------ /hosts JSON cache ------------------------
+
+/**
+ * Adds the "host" key with the given host name (or null) to a JSON object.
+ */
+void add_host_to_json(cJSON *json_obj, const char *host);
+
+/**
+ * Adds {master, alive, lag_ms, lag_bytes, sync_by_*, lsn} keys to a JSON
+ * object, derived from the snapshot.
+ */
+void add_host_status_to_json(cJSON *json_obj, MonitorSnapshot snap);
+
+/**
+ * Rebuilds the cached JSON representation of all hosts. Called by the
+ * poll thread after every check_hosts iteration. Lock-free: a new entry
+ * is published via atomic_exchange, the previous one stays alive for
+ * one extra cycle as a grace period for in-flight readers.
+ */
+void update_hosts_cache(void);
+
+/**
+ * Returns a fresh malloc'ed copy of the cached /hosts JSON and writes
+ * its length to *len. Returns nullptr if the cache hasn't been built
+ * yet. The result must be freed by the caller.
+ */
+char *copy_hosts_cache(size_t *len);
+
+/**
+ * Releases the /hosts JSON cache. Called on shutdown.
+ */
+void free_hosts_cache(void);
 
 // ------------------------ Lookup utils ------------------------
 


### PR DESCRIPTION
Закрывает #14.

## Что
Раньше на каждый запрос `/hosts` заново строился cJSON-массив с десятком malloc'ов и `cJSON_PrintUnformatted`. Writer обновляет статусы раз в `pg_status__sleep` секунд против тысяч чтений/сек — идеальное соотношение для кеша.

- host_list.c хранит готовую JSON-строку под `pthread_rwlock_t`
- `update_hosts_cache()` вызывается monitor-потоком после каждого `check_hosts()`; cJSON-сборка идёт **вне** lock'а, под `wrlock` выполняется только swap указателя и присваивание длины
- `copy_hosts_cache()` выдаёт читателю свежую malloc'ом копию — ответ уходит через `MHD_RESPMEM_MUST_FREE`, не зависит от lifetime кеша
- `get_all_hosts` (main.c) превратился в чтение кеша; если кеш ещё не построен (теоретически до первого `check_hosts`), уходит пустой массив `"[]"`
- `free_hosts_cache()` вызывается на shutdown после `pthread_join`

## Замечания по реализации
- Через `MHD_RESPMEM_MUST_FREE` отдаём отдельную malloc'нутую копию вместо референса на кеш — чтобы lifetime ответа MHD не пересекался с возможным `update_hosts_cache` от writer'а. Альтернатива — RCU/hazard pointer, что усложняет код.
- `malloc + memcpy` под `rdlock` короче, чем cJSON-сборка, и не мешает другим readerам.

## Проверено
- cmake Release собирается без новых warning'ов

## Стоит проверить руками
- `curl .../hosts` отдаёт тот же JSON, что и до патча
- hey-бенчмарк `/hosts` на одинаковой конфигурации показывает прирост RPS относительно baseline
- graceful shutdown отрабатывает без segfault (writer закрывается, кеш освобождается)
- valgrind в `test/valgrind/` чист