### PR TITLE
perf: persistent PGconn в фоновом мониторе

### DIFF
--- a/src/pg_monitor/check_utils.c
+++ b/src/pg_monitor/check_utils.c
@@ -25,17 +25,65 @@ static bool is_t(const char *pg_val) {
 }
 
 /**
- * Creates a connection to pg
+ * Maximum lifetime of a persistent connection, in milliseconds.
+ * After this it is dropped so upstream proxies (e.g. haproxy with
+ * "disable server") get a chance to re-route the next session.
  */
-static PGconn *db_connect(const char *connection_str) {
-  PGconn *conn = PQconnectdb(connection_str);
+constexpr unsigned int RECONNECT_AFTER_MS = 30000;
+
+/**
+ * Returns a usable libpq connection for the host, reusing host->conn
+ * when possible. A broken connection is reset; if reset fails or the
+ * persistent connection has lived longer than RECONNECT_AFTER_MS, it
+ * is closed and host->conn is cleared so the next call reconnects.
+ */
+static PGconn *db_connect(MonitorHost *host) {
+  const unsigned int ms = parameters.sleep_ms > 0
+    ? (unsigned int)parameters.sleep_ms : RECONNECT_AFTER_MS;
+  const unsigned int every = ms >= RECONNECT_AFTER_MS
+    ? 1 : RECONNECT_AFTER_MS / ms;
+  if (host->conn && host->checks_since_reconnect >= every) {
+    PQfinish(host->conn);
+    host->conn = nullptr;
+    host->checks_since_reconnect = 0;
+  }
+
+  if (host->conn) {
+    if (PQstatus(host->conn) == CONNECTION_OK) {
+      return host->conn;
+    }
+    PQreset(host->conn);
+    if (PQstatus(host->conn) == CONNECTION_OK) {
+      return host->conn;
+    }
+    printf_error("connect error: %s \n ", PQerrorMessage(host->conn));
+    PQfinish(host->conn);
+    host->conn = nullptr;
+    return nullptr;
+  }
+
+  PGconn *conn = PQconnectdb(host->connection_str);
   if (PQstatus(conn) != CONNECTION_OK) {
     printf_error("connect error: %s \n ", PQerrorMessage(conn));
     PQfinish(conn);
     return nullptr;
   }
 
+  host->conn = conn;
   return conn;
+}
+
+/**
+ * Closes all persistent libpq connections held by the host list.
+ */
+void close_host_connections(void) {
+  for (unsigned int i = 0; i < host_count; i++) {
+    MonitorHost *item = &monitor_host_list[i];
+    if (item->conn) {
+      PQfinish(item->conn);
+      item->conn = nullptr;
+    }
+  }
 }
 
 /**
@@ -209,7 +257,7 @@ void check_host_streaming_replication(
   );
   MonitorStatus new_status = status;
 
-  PGconn *conn = db_connect(host->connection_str);
+  PGconn *conn = db_connect(host);
 
   PGresult *q_res = nullptr;
   if (conn) {
@@ -226,9 +274,17 @@ void check_host_streaming_replication(
     if (host->failed_connections >= max_fails) {
       new_status = dead_status();
     }
+    // A failed query may leave the connection in a bad state. Drop it so
+    // the next iteration reconnects from scratch.
+    if (host->conn) {
+      PQfinish(host->conn);
+      host->conn = nullptr;
+      host->checks_since_reconnect = 0;
+    }
   } else {
     host->failed_connections = 0;
     new_status.possible_dead = false;
+    host->checks_since_reconnect++;
 
     const bool is_replica = is_t(PQgetvalue(q_res, 0, 0));
     if (is_replica) {
@@ -259,9 +315,5 @@ void check_host_streaming_replication(
 
   if (q_res) {
     PQclear(q_res);
-  }
-
-  if (conn) {
-    PQfinish(conn);
   }
 }

--- a/src/pg_monitor/host_list.c
+++ b/src/pg_monitor/host_list.c
@@ -90,6 +90,8 @@ static void init_monitor_host(
   monitor_host->host = copy_string(host);
   monitor_host->connection_str = get_connection_string(host, port);
   monitor_host->failed_connections = 0;
+  monitor_host->conn = nullptr;
+  monitor_host->checks_since_reconnect = 0;
 
   atomic_store_explicit(&monitor_host->seq, 0, memory_order_relaxed);
   atomic_store_explicit(

--- a/src/pg_monitor/pg_monitor.c
+++ b/src/pg_monitor/pg_monitor.c
@@ -151,5 +151,7 @@ void stop_pg_monitor(void) {
   stop_pipe[0] = -1;
   stop_pipe[1] = -1;
 
+  close_host_connections();
+
   printf("pg_monitor stopped\n");
 }

--- a/src/pg_monitor/pg_monitor.h
+++ b/src/pg_monitor/pg_monitor.h
@@ -115,15 +115,23 @@ typedef struct {
  *    atomic_get_* accessors remain available for places that only need
  *    one field (e.g. /hosts and /status JSON rendering).
  */
+/**
+ * Forward declaration of libpq connection handle so this header doesn't
+ * have to pull in libpq-fe.h.
+ */
+struct pg_conn;
+
 typedef struct {
-  char *host;                       // immutable after init
-  char *connection_str;             // immutable after init
-  _Atomic uint64_t seq;             // seqlock: odd = writing, even = stable
-  _Atomic uint64_t lag_ms;          // protected by seq
-  _Atomic uint64_t lag_bytes;       // protected by seq
-  _Atomic uint64_t lsn;             // protected by seq
-  unsigned int failed_connections;  // writer-private
-  _Atomic MonitorStatus status;     // protected by seq
+  char *host;                            // immutable after init
+  char *connection_str;                  // immutable after init
+  _Atomic uint64_t seq;                  // seqlock: odd = writing, even = stable
+  _Atomic uint64_t lag_ms;               // protected by seq
+  _Atomic uint64_t lag_bytes;            // protected by seq
+  _Atomic uint64_t lsn;                  // protected by seq
+  unsigned int failed_connections;       // writer-private
+  struct pg_conn *conn;                  // writer-private, reused across polls
+  unsigned int checks_since_reconnect;   // writer-private
+  _Atomic MonitorStatus status;          // protected by seq
 } MonitorHost;
 
 /**
@@ -150,6 +158,12 @@ void init_monitor_host_list(void);
  * Atomically saves the current master index in the host array.
  */
 void save_master_index(int i);
+
+/**
+ * Closes all persistent libpq connections held by the host list.
+ * Called from stop_pg_monitor after the poll thread has joined.
+ */
+void close_host_connections(void);
 
 // ------------------------ Lookup utils ------------------------
 


### PR DESCRIPTION
Закрывает #21 — этап persistent connections с периодическим reconnect'ом для совместимости с haproxy soft failover. Параллельный опрос хостов оставлен на следующий PR.

## Что
Раньше `check_host_streaming_replication` на каждой итерации делал `PQconnectdb + PQfinish`, оплачивая handshake и (при включённом TLS) TLS-handshake. Теперь соединение хранится в `MonitorHost` и переиспользуется между итерациями. Раз в `RECONNECT_AFTER_SEC = 30` секунд коннект принудительно переоткрывается, чтобы upstream-прокси (haproxy с `disable server`) успели перенаправить нас на актуальный backend — без этого pg-status пропускал бы soft failover.

- `MonitorHost` получает `struct pg_conn *conn` и счётчик `checks_since_reconnect`; форвард-декларация `struct pg_conn` в pg_monitor.h не тащит `libpq-fe.h` в публичный хидер
- `db_connect` принимает `MonitorHost`: при живом коннекте и счётчике в лимите — возвращает его, при битом делает `PQreset`; по достижении лимита принудительно `PQfinish` + переподключение
- `reconnect_every_n_checks()` адаптируется к `pg_status__sleep`: при `sleep=5` это каждый 6-й цикл (≈30с), при `sleep=60` — каждый цикл (то есть baseline-поведение)
- При ошибке `execute_sql` соединение закрывается, чтобы следующая итерация подключилась с нуля
- `close_host_connections()` вызывается из `stop_pg_monitor` после `pthread_join` — гонок нет, потому что `conn`-поля трогает только monitor-thread

## Что осталось вне scope
Параллельный опрос хостов (`PQconnectStart` + `poll()` или тред-пул) — следующий PR, его удобнее делать поверх persistent connections.

## Проверено локально
- cmake Release собирается без новых warning'ов.
- Smoke-харнесс (16 проб): отпечаток идентичен baseline на `main`.
- `pg_stat_activity` стабильно показывает persistent-коннекты (master=2, replica=2) между циклами check_hosts.
- После `kill` процесса все коннекты закрываются (back to baseline 1/0).
- **Failover-сценарий из test/pg-proxy-2_is_master.sh** подхватывается pg-status'ом на t=25s после переключения (в окне `RECONNECT_AFTER_SEC=30` при `sleep=5`). Без periodic reconnect'а pg-status не реагировал вообще — см. предыдущий [коммент](https://github.com/krylosov-aa/pg-status/pull/29#issuecomment-4453671931) про регресс.