### PR TITLE
[codex] Improve lint and format tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[CMakeLists.txt]
+indent_size = 4
+
+[*.cmake]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .env
 
+/cmake-build-*/
+/scan_reports/
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,14 @@ project(pg-status C)
 
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_C_CLANG_TIDY "clang-tidy")
+find_program(CLANG_TIDY_EXE NAMES clang-tidy)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND CLANG_TIDY_EXE)
+    set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_EXE}")
+elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(WARNING "clang-tidy not found; Debug builds will skip clang-tidy")
 endif()
 
 add_library(common_warnings INTERFACE)
@@ -36,14 +41,17 @@ target_link_options(common_warnings INTERFACE
 find_package(PkgConfig REQUIRED)
 add_subdirectory(src)
 
+file(GLOB_RECURSE FORMAT_SOURCES
+        "${CMAKE_SOURCE_DIR}/src/*.c"
+        "${CMAKE_SOURCE_DIR}/src/*.h"
+)
+
+file(GLOB_RECURSE LINT_SOURCES
+        "${CMAKE_SOURCE_DIR}/src/*.c"
+)
+
 find_program(CLANG_FORMAT_EXE NAMES clang-format)
-
 if(CLANG_FORMAT_EXE)
-    file(GLOB_RECURSE FORMAT_SOURCES
-            "${CMAKE_SOURCE_DIR}/src/*.c"
-            "${CMAKE_SOURCE_DIR}/src/*.h"
-    )
-
     add_custom_target(format
             COMMAND ${CLANG_FORMAT_EXE} -i ${FORMAT_SOURCES}
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -67,4 +75,32 @@ if(CLANG_FORMAT_EXE)
     elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
         add_dependencies(pg-status format-check)
     endif()
+else()
+    add_custom_target(format
+            COMMAND ${CMAKE_COMMAND} -E echo "clang-format not found"
+            COMMAND ${CMAKE_COMMAND} -E false
+    )
+
+    add_custom_target(format-check
+            COMMAND ${CMAKE_COMMAND} -E echo "clang-format not found"
+            COMMAND ${CMAKE_COMMAND} -E false
+    )
+
+    add_custom_target(format-warn
+            COMMAND ${CMAKE_COMMAND} -E echo "clang-format not found"
+            COMMAND ${CMAKE_COMMAND} -E false
+    )
+endif()
+
+if(CLANG_TIDY_EXE)
+    add_custom_target(lint
+            COMMAND ${CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR} ${LINT_SOURCES}
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMENT "clang-tidy: checking sources"
+    )
+else()
+    add_custom_target(lint
+            COMMAND ${CMAKE_COMMAND} -E echo "clang-tidy not found"
+            COMMAND ${CMAKE_COMMAND} -E false
+    )
 endif()

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,19 @@
+cmake ?= cmake
+debug_build_dir ?= cmake-build-debug
+release_build_dir ?= cmake-build-release
+
+configure_debug:
+	$(cmake) -S . -B $(debug_build_dir) -DCMAKE_BUILD_TYPE=Debug
+
+configure_release:
+	$(cmake) -S . -B $(release_build_dir) -DCMAKE_BUILD_TYPE=Release
+
+build_debug: configure_debug
+	$(cmake) --build $(debug_build_dir)
+
+build_release: configure_release
+	$(cmake) --build $(release_build_dir)
+
 build_static_alpine:
 	docker build -f docker/alpine/Dockerfile_static -t pg-status-static-alpine .
 
@@ -62,14 +78,14 @@ down_test:
 
 
 
-scan-build:
-	scan-build -o scan_reports cmake --build cmake-build-release
+scan-build: configure_release
+	scan-build -o scan_reports $(cmake) --build $(release_build_dir)
 
 clean:
-	 cmake --build cmake-build-debug --verbose --target clean
+	$(cmake) --build $(debug_build_dir) --verbose --target clean
 
 clean_release:
-	 cmake --build cmake-build-release --verbose --target clean
+	$(cmake) --build $(release_build_dir) --verbose --target clean
 
 build_valgrind:
 	docker build -f test/valgrind/Dockerfile -t pg-status-valgrind .
@@ -86,5 +102,14 @@ build_push_amd_64:
 	sudo docker push ${r}/pg-status:${v}
 	sudo docker push ${r}/pg-status:latest
 
-format-warn:
-	cmake --build cmake-build-debug --target format-warn
+format: configure_debug
+	$(cmake) --build $(debug_build_dir) --target format
+
+format-check: configure_release
+	$(cmake) --build $(release_build_dir) --target format-check
+
+format-warn: configure_debug
+	$(cmake) --build $(debug_build_dir) --target format-warn
+
+lint: configure_debug
+	$(cmake) --build $(debug_build_dir) --target lint

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ For replicas, there are also messages about replica synchronicity against the gl
 
 You can start the containers and test the application however you like.
 
+For local formatting and linting commands, see [docs/development.md](docs/development.md).
+
 ### make build_up
 
 Builds [the lightweight container]((docker/alpine/Dockerfile_shared)) using parameters defined in

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,33 @@
+# Development
+
+## Formatting and linting
+
+The project uses `clang-format` for C source formatting and `clang-tidy`
+for static analysis. Both tools are wired through CMake.
+
+Common commands:
+
+```shell
+make format
+make format-check
+make format-warn
+make lint
+```
+
+`make format` rewrites source files in place. `make format-check` checks
+formatting and fails on differences. `make lint` runs `clang-tidy` against
+the sources in `src`.
+
+The commands configure the required CMake build directory automatically:
+
+```shell
+make configure_debug
+make configure_release
+```
+
+On macOS, the Homebrew `llvm` package may not be added to `PATH`
+automatically. If needed, expose the LLVM tools explicitly:
+
+```shell
+export PATH="$(brew --prefix llvm)/bin:$PATH"
+```


### PR DESCRIPTION
## Summary

- Add self-contained Makefile targets for Debug/Release CMake configuration, formatting, format checks, linting, and local builds.
- Make CMake expose explicit `format`, `format-check`, `format-warn`, and `lint` targets even when the required LLVM tools are missing, so failures are clear.
- Enable `compile_commands.json`, add editor defaults, ignore generated CMake/scan-build output, and document the local development commands.

## Why

The project already had `clang-format`, `clang-tidy`, compiler warnings, and `scan-build` wiring, but the workflow depended on pre-existing local build directories and did not expose a direct lint target. The new targets make the existing infrastructure easier to run consistently without changing the tool stack.

## Validation

- `cmake -S . -B /private/tmp/pg-status-cmake-debug-verify -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B /private/tmp/pg-status-cmake-release-verify -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /private/tmp/pg-status-cmake-debug-verify --target help`
- `make -n format format-check format-warn lint build_debug build_release scan-build`
- `git diff --check`

Note: local `clang-format` and `clang-tidy` were not available in `PATH`, so the actual formatting and lint targets were not executed locally; CMake now reports those missing tools explicitly.
